### PR TITLE
BP-5296: Adds github pages CNAME

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+developers.certifaction.com


### PR DESCRIPTION
Add the `developers.certifaction.com` CNAME configuration for github pages custom domain.